### PR TITLE
feat: 미팅 조회 페이지 구현(주, 월)

### DIFF
--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -8,6 +8,8 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@fullcalendar/daygrid": "^5.11.2",
+        "@fullcalendar/react": "^5.11.2",
         "@tanstack/react-query": "^4.0.10",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.3.0",
@@ -2223,6 +2225,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fullcalendar/common": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/common/-/common-5.11.2.tgz",
+      "integrity": "sha512-2YBRs4IFrZlo7UL7hEHK+QgnuQnVIfwSspCOy0Qe+DtU2hu3myPrxsW0Tt/8RaoWsRndRDw5jeJzpjcVHDSSGQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.11.2.tgz",
+      "integrity": "sha512-WmR8EAOR8Y9wyxlCK2gBW6lG/dPSN37eM8L7vgc7YgrQE1knL7ISgaUnDfFUNBFztmLakO/ZpeQQFpz3pnJwXg==",
+      "dependencies": {
+        "@fullcalendar/common": "~5.11.2",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-5.11.2.tgz",
+      "integrity": "sha512-OnLvfV406VEQcK4QGN8xR4ro6Manp9dKE7/n9dhs19J1kKpqS1w1sIEYg1dT11njbk0Ob+TdF3cXLDFq73jUlA==",
+      "dependencies": {
+        "@fullcalendar/common": "~5.11.2",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.7.0 || ^17 || ^18",
+        "react-dom": "^16.7.0 || ^17 || ^18"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -18384,6 +18416,32 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
+      }
+    },
+    "@fullcalendar/common": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/common/-/common-5.11.2.tgz",
+      "integrity": "sha512-2YBRs4IFrZlo7UL7hEHK+QgnuQnVIfwSspCOy0Qe+DtU2hu3myPrxsW0Tt/8RaoWsRndRDw5jeJzpjcVHDSSGQ==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@fullcalendar/daygrid": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.11.2.tgz",
+      "integrity": "sha512-WmR8EAOR8Y9wyxlCK2gBW6lG/dPSN37eM8L7vgc7YgrQE1knL7ISgaUnDfFUNBFztmLakO/ZpeQQFpz3pnJwXg==",
+      "requires": {
+        "@fullcalendar/common": "~5.11.2",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@fullcalendar/react": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-5.11.2.tgz",
+      "integrity": "sha512-OnLvfV406VEQcK4QGN8xR4ro6Manp9dKE7/n9dhs19J1kKpqS1w1sIEYg1dT11njbk0Ob+TdF3cXLDFq73jUlA==",
+      "requires": {
+        "@fullcalendar/common": "~5.11.2",
+        "tslib": "^2.1.0"
       }
     },
     "@humanwhocodes/config-array": {

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fullcalendar/daygrid": "^5.11.2",
+    "@fullcalendar/react": "^5.11.2",
     "@tanstack/react-query": "^4.0.10",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",

--- a/frontend/web/src/globalStyles.tsx
+++ b/frontend/web/src/globalStyles.tsx
@@ -19,7 +19,7 @@ time, mark, audio, video {
   padding: 0;
   border: 0;
   font-size: 100%;
-  font: inherit;
+  /* font: inherit; */
   vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */

--- a/frontend/web/src/pages/meeting.tsx
+++ b/frontend/web/src/pages/meeting.tsx
@@ -1,7 +1,32 @@
 import React from 'react';
+import styled from 'styled-components';
+
+import Calendar from '../templates/calendar';
+
+const Container = styled.div`
+    padding: 3rem 5% 3rem 5%;
+`;
 
 const Meeting: React.FC = () => {
-    return <div>Meeting page</div>;
+    return (
+        <Container>
+            <Calendar
+                customButtons={{
+                    addMeeting: {
+                        text: '미팅 추가',
+                        click: () => {
+                            console.log('미팅 추가');
+                        },
+                    },
+                }}
+                headerToolBar={{
+                    left: 'addMeeting',
+                    center: 'prev,title,next',
+                    right: 'dayGridWeek,dayGridMonth',
+                }}
+            />
+        </Container>
+    );
 };
 
 export default Meeting;

--- a/frontend/web/src/templates/calendar.tsx
+++ b/frontend/web/src/templates/calendar.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import FullCalendar, {
+    ButtonTextCompoundInput,
+    CustomButtonInput,
+    PluginDef,
+    ToolbarInput,
+} from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import styled from 'styled-components';
+
+const Container = styled.div`
+    /* padding: 3rem 5% 0 5%; */
+    .fc {
+        height: calc(100vh - 11rem);
+    }
+
+    .fc .fc-header-toolbar .fc-toolbar-chunk div {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
+
+    .fc .fc-addMeeting-button {
+        width: 100%;
+    }
+
+    .fc .fc-toolbar-chunk:nth-child(1) {
+        width: 14%;
+    }
+    .fc .fc-toolbar-chunk:nth-child(3) {
+        width: 14%;
+    }
+
+    .fc .fc-toolbar-title {
+        padding: 0 1rem 0 1rem;
+    }
+
+    .fc .fc-toolbar-chunk .fc-prev-button,
+    .fc .fc-toolbar-chunk .fc-next-button {
+        height: 2rem;
+        width: 2rem;
+        padding: 0;
+    }
+
+    .fc .fc-button {
+        border: none;
+    }
+
+    .fc .fc-button-group > .fc-button {
+        background-color: ${({ theme }) => theme.secondaryColor};
+    }
+    .fc .fc-button-group > .fc-button.fc-button-active,
+    .fc .fc-button:hover,
+    .fc .fc-button-primary {
+        background-color: ${({ theme }) => theme.primaryColor};
+    }
+
+    .fc .fc-col-header-cell {
+        background-color: ${({ theme }) => theme.primaryColor};
+        color: white;
+    }
+
+    .fc .fc-col-header-cell .fc-scrollgrid-sync-inner {
+        height: 3rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+`;
+
+type CalendarProps = {
+    plugins?: PluginDef[];
+    initialView?: string;
+    customButtons: { [name: string]: CustomButtonInput };
+    headerToolBar: false | ToolbarInput;
+    buttonText?: ButtonTextCompoundInput;
+};
+
+const Calendar: React.FC<CalendarProps> = ({
+    plugins = [dayGridPlugin],
+    initialView = 'dayGridWeek',
+    customButtons,
+    headerToolBar,
+    buttonText = {
+        month: 'Month',
+        week: 'Week',
+    },
+}: CalendarProps) => {
+    return (
+        <Container>
+            <FullCalendar
+                plugins={plugins}
+                initialView={initialView}
+                customButtons={customButtons}
+                headerToolbar={headerToolBar}
+                buttonText={buttonText}
+            />
+        </Container>
+    );
+};
+
+export default Calendar;


### PR DESCRIPTION
- [x] 주 단위 캘린더 구현
- [x] 월 단위 캘린더 구현
- [x] 미팅 추가 버튼 구현
- [x] 캘린더에 figma ui 적용

- todo : 구글 캘린더 api 적용 후 데이터 바인딩, 미팅 추가, 일 단위 상세보기 구현
#10